### PR TITLE
Fixed overlay reset

### DIFF
--- a/scripts/overlay.js
+++ b/scripts/overlay.js
@@ -24,11 +24,10 @@ const isFirefox = typeof InstallTrigger !== 'undefined';
 			return !!_overlay && _overlay.HasOverlay;
 		};
 		$container = $('.ocrext-textoverlay-container');
-
 		htmlString = [
 			'<div class="ocrext-element ocrext-text-overlay">',
 			'<div class="ocrext-element ocrext-text-overlay-word-wrapper">',
-			'<img class="ocrext-element ocrext-text-overlay-img text-overlay-img" />',
+			'<img class="ocrext-element ocrext-text-overlay-img" id="text-overlay-img" />',
 			'</div>',
 			'</div>'
 		].join('');
@@ -98,17 +97,15 @@ const isFirefox = typeof InstallTrigger !== 'undefined';
 			},
 
 			setDimensions: function (width, height) {
-
 				$.each([$overlay, $overlay.find('.ocrext-text-overlay-word-wrapper')], function () {
 					this.width(width).height(height);
 				});
-
 				return this;
 			},
 
 			reset: function () {
 				_overlay = null;
-				$overlay.find('.ocrext-text-overlay-word-wrapper span').remove();
+				$overlay.find('.ocrext-text-overlay').remove();
 				return this;
 			},
 
@@ -159,8 +156,6 @@ const isFirefox = typeof InstallTrigger !== 'undefined';
 					if (sender.tab) {
 						return true;
 					}
-
-
 
 					if (request.evt === 'init-overlay-tab') {
 						self.setOverlayInformation(request.overlayInfo, request.canWidth, request.canHeight, request.imgDataURI, request.zoom);


### PR DESCRIPTION
## **Summary**
when initiating a new OCR, the previous content needs to be reset/removed. Now, the issue here, with removing only the ```ocrext-text-overlay-word-wrapper span``` is DOM still have ```ocrext-text-overlay``` and ```ocrext-text-overlay-word-wrapper``` <br>
![image](https://user-images.githubusercontent.com/44097148/102718566-df4e8400-430e-11eb-8f8e-69640f78b36e.png)
<br>
so, when it populates the content of next OCR rather than doing it once it just populates in all the ```ocrext-text-overlay-word-wrapper``` classes present in DOM.<br>
![image](https://user-images.githubusercontent.com/44097148/102718784-06f21c00-4310-11eb-9497-092a8de2b7fe.png)

### *Solution*
Any easy solution for this is to remove all the ```ocrext-text-overlay``` classes rather than just `span` so that when it renders the new content, it only populates it once.
So, no matter how much times you do the OCR it never duplicate the data and the best part is it also increase performance on old/slow devices. [after a couple of OCR since it no longer store the redundant data]